### PR TITLE
Remove file upload feature from meeting minutes

### DIFF
--- a/e2etest/tests/admin/minutes.spec.ts
+++ b/e2etest/tests/admin/minutes.spec.ts
@@ -1,6 +1,5 @@
 import { test, expect } from '@playwright/test';
 import { AdminMinutesPage } from '../pages/admin/AdminMinutesPage';
-import path from 'path';
 
 test.use({ storageState: 'tests/.auth/admin.json' });
 
@@ -14,7 +13,7 @@ const TEST_MINUTES = {
 // WF-ADM-07: Manage Minutes — Edit
 // WF-ADM-08: Manage Minutes — Delete
 test.describe('WF-ADM-06: Minutes — Create', () => {
-  test('happy path — create minutes without file', async ({ page }) => {
+  test('happy path — create minutes appears in list', async ({ page }) => {
     const minutesPage = new AdminMinutesPage(page);
     await minutesPage.goto();
 
@@ -25,41 +24,15 @@ test.describe('WF-ADM-06: Minutes — Create', () => {
     await expect(page.getByText(TEST_MINUTES.title).first()).toBeVisible({ timeout: 8000 });
   });
 
-  test('edge case — invalid file type rejected by upload API', async ({ page }) => {
+  test('edge case — no content saves minutes with title only', async ({ page }) => {
     const minutesPage = new AdminMinutesPage(page);
     await minutesPage.goto();
 
     await minutesPage.newMinutesBtn.click();
-
-    // Intercept the upload endpoint to simulate rejection
-    await page.route(/\/api\/upload/, (route) =>
-      route.fulfill({ status: 400, body: JSON.stringify({ error: 'Invalid file type' }) })
-    );
-
-    // Trigger file upload with a fake file
-    const fileChooserPromise = page.waitForEvent('filechooser');
-    await minutesPage.fileInput.click();
-    const fileChooser = await fileChooserPromise;
-    await fileChooser.setFiles({
-      name: 'malware.exe',
-      mimeType: 'application/octet-stream',
-      buffer: Buffer.from('fake file content'),
-    });
-
-    // Upload error should be visible
-    const errorVisible = await page.getByText(/invalid|error|failed/i).first().waitFor({ state: 'visible', timeout: 5000 }).then(() => true).catch(() => false);
-    expect(errorVisible).toBeTruthy();
-  });
-
-  test('edge case — no file selected saves minutes with content preview', async ({ page }) => {
-    const minutesPage = new AdminMinutesPage(page);
-    await minutesPage.goto();
-
-    await minutesPage.newMinutesBtn.click();
-    await minutesPage.fillMinutesForm({ ...TEST_MINUTES, title: 'No File Minutes' });
+    await minutesPage.fillMinutesForm({ ...TEST_MINUTES, title: 'No Content Minutes', content: 'placeholder' });
     await minutesPage.submitBtn.click();
 
-    await expect(page.getByText('No File Minutes').first()).toBeVisible({ timeout: 8000 });
+    await expect(page.getByText('No Content Minutes').first()).toBeVisible({ timeout: 8000 });
   });
 });
 
@@ -84,37 +57,18 @@ test.describe('WF-ADM-07: Minutes — Edit', () => {
     await expect(page.getByText(updatedTitle).first()).toBeVisible({ timeout: 8000 });
   });
 
-  test('edge case — re-upload sets new fileUrl (old file orphaned)', async ({ page }) => {
+  test('edge case — edit content updates the record', async ({ page }) => {
     const minutesPage = new AdminMinutesPage(page);
     await minutesPage.goto();
 
     const editBtns = minutesPage.getEditBtns();
-    const count = await editBtns.count();
-    if (count === 0) test.skip();
+    if (await editBtns.count() === 0) test.skip();
 
     await editBtns.first().click();
+    await minutesPage.contentInput.fill('Updated content from E2E test.');
+    await minutesPage.submitBtn.click();
 
-    // Intercept upload to return a mock new URL
-    await page.route(/\/api\/upload/, (route) =>
-      route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({ fileUrl: 'https://example.com/new-file.pdf' }),
-      })
-    );
-
-    const fileChooserPromise = page.waitForEvent('filechooser');
-    await minutesPage.fileInput.click();
-    const fileChooser = await fileChooserPromise;
-    await fileChooser.setFiles({
-      name: 'new-minutes.pdf',
-      mimeType: 'application/pdf',
-      buffer: Buffer.from('PDF content'),
-    });
-
-    // Upload should succeed — filename or URL change visible in form
-    const uploadFeedback = page.getByText(/new-minutes\.pdf|uploaded/i);
-    await expect(uploadFeedback).toBeVisible({ timeout: 5000 });
+    await expect(page.locator('body')).not.toContainText(/error|500/i);
   });
 });
 
@@ -125,7 +79,6 @@ test.describe('WF-ADM-08: Minutes — Delete', () => {
 
     const toDelete = `Minutes To Delete ${Date.now()}`;
 
-    // Create a minutes record to delete
     await minutesPage.newMinutesBtn.click();
     await minutesPage.fillMinutesForm({ ...TEST_MINUTES, title: toDelete });
     await minutesPage.submitBtn.click();

--- a/e2etest/tests/pages/MinutesPage.ts
+++ b/e2etest/tests/pages/MinutesPage.ts
@@ -23,7 +23,4 @@ export class MinutesPage {
     });
   }
 
-  getDownloadButtons() {
-    return this.page.getByRole('link', { name: /download minutes/i });
-  }
 }

--- a/e2etest/tests/pages/admin/AdminMinutesPage.ts
+++ b/e2etest/tests/pages/admin/AdminMinutesPage.ts
@@ -6,7 +6,6 @@ export class AdminMinutesPage {
   readonly titleInput: Locator;
   readonly dateInput: Locator;
   readonly contentInput: Locator;
-  readonly fileInput: Locator;
   readonly submitBtn: Locator;
   readonly confirmDeleteBtn: Locator;
   readonly cancelDeleteBtn: Locator;
@@ -17,7 +16,6 @@ export class AdminMinutesPage {
     this.titleInput = page.getByLabel(/title/i);
     this.dateInput = page.getByLabel(/date/i);
     this.contentInput = page.getByLabel(/content/i);
-    this.fileInput = page.locator('input[type="file"]');
     this.submitBtn = page.getByRole('button', { name: /post|update|save|submit|create/i }).last();
     this.confirmDeleteBtn = page.getByTestId('confirm-delete-btn');
     this.cancelDeleteBtn = page.getByTestId('cancel-delete-btn');

--- a/e2etest/tests/public/minutes.spec.ts
+++ b/e2etest/tests/public/minutes.spec.ts
@@ -31,18 +31,6 @@ test.describe('WF-PUB-04: Minutes Archive', () => {
     }
   });
 
-  test('happy path — download button present on card with fileUrl', async ({ page }) => {
-    const minutesPage = new MinutesPage(page);
-    await minutesPage.goto();
-
-    const downloadBtns = minutesPage.getDownloadButtons();
-    const count = await downloadBtns.count();
-    if (count > 0) {
-      await expect(downloadBtns.first()).toBeVisible();
-      await expect(downloadBtns.first()).toHaveAttribute('href', /.+/);
-    }
-  });
-
   test('happy path — clicking a minutes card navigates to detail page', async ({ page }) => {
     const minutesPage = new MinutesPage(page);
     await minutesPage.goto();
@@ -75,13 +63,8 @@ test.describe('WF-PUB-04: Minutes Archive', () => {
     const cards = minutesPage.getMinutesCards();
     const count = await cards.count();
     if (count > 0) {
-      // Cards without a download button show a content preview — it should not start with # or *
-      const downloadBtns = minutesPage.getDownloadButtons();
-      const downloadCount = await downloadBtns.count();
-      if (downloadCount === 0) {
-        const text = await cards.first().textContent() ?? '';
-        expect(text.trimStart()).not.toMatch(/^[#*]/);
-      }
+      const text = await cards.first().textContent() ?? '';
+      expect(text.trimStart()).not.toMatch(/^[#*]/);
     }
   });
 });
@@ -89,7 +72,6 @@ test.describe('WF-PUB-04: Minutes Archive', () => {
 // WF-PUB-05: Read Meeting Minutes Detail
 test.describe('WF-PUB-05: Minutes Detail', () => {
   test('happy path — back link present', async ({ page }) => {
-    // Navigate to minutes list first to get a real ID
     await page.goto('/minutes');
     const cards = page.locator('article, li, [class*="card"]').filter({ has: page.locator('a[href*="/minutes/"]') });
     const count = await cards.count();
@@ -123,7 +105,6 @@ test.describe('WF-PUB-05: Minutes Detail', () => {
     const detailPage = new MinutesDetailPage(page);
     await detailPage.goto('nonexistent-id-000');
 
-    // Next.js notFound() triggers a 404 page
     const status = page.locator('h1, h2').filter({ hasText: /404|not found/i });
     await expect(status).toBeVisible();
   });

--- a/src/__tests__/unit/components/MinutesCard.test.tsx
+++ b/src/__tests__/unit/components/MinutesCard.test.tsx
@@ -7,7 +7,6 @@ const mockMinutes: Minutes = {
     title: 'February 2026 Meeting',
     date: '2026-02-05',
     content: 'Budget review and event planning.',
-    fileUrl: 'https://example.com/minutes.pdf',
     createdAt: '2026-02-05T19:00:00Z',
 };
 

--- a/src/app/admin/minutes/page.tsx
+++ b/src/app/admin/minutes/page.tsx
@@ -8,7 +8,6 @@ interface MinutesData {
   title: string;
   date: string;
   content: string;
-  fileUrl?: string; // Add optional fileUrl
   createdAt: string;
 }
 
@@ -16,7 +15,6 @@ const emptyMinutes = {
   title: "",
   date: "",
   content: "",
-  fileUrl: "", // Add default empty fileUrl
 };
 
 export default function AdminMinutesPage() {
@@ -25,7 +23,6 @@ export default function AdminMinutesPage() {
   const [form, setForm] = useState(emptyMinutes);
   const [showForm, setShowForm] = useState(false);
   const [deleteId, setDeleteId] = useState<string | null>(null);
-  const [uploadError, setUploadError] = useState("");
 
   useEffect(() => {
     fetchMinutes();
@@ -44,41 +41,14 @@ export default function AdminMinutesPage() {
       title: item.title,
       date: item.date,
       content: item.content,
-      fileUrl: item.fileUrl || "",
     });
-    setUploadError("");
     setShowForm(true);
   }
 
   function handleNew() {
     setEditing(null);
     setForm(emptyMinutes);
-    setUploadError("");
     setShowForm(true);
-  }
-
-  async function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
-    const file = e.target.files?.[0];
-    if (!file) return;
-
-    const formData = new FormData();
-    formData.append("file", file);
-
-    try {
-      const res = await fetch("/api/upload?context=document", {
-        method: "POST",
-        body: formData,
-      });
-
-      if (!res.ok) throw new Error("Upload failed");
-
-      const data = await res.json();
-      setUploadError("");
-      setForm((prev) => ({ ...prev, fileUrl: data.fileUrl }));
-    } catch (error) {
-      console.error("Upload error:", error);
-      setUploadError("File upload failed. Invalid file type.");
-    }
   }
 
   async function handleSubmit(e: React.FormEvent) {
@@ -101,7 +71,6 @@ export default function AdminMinutesPage() {
     setShowForm(false);
     setEditing(null);
     setForm(emptyMinutes);
-    setUploadError("");
     fetchMinutes();
   }
 
@@ -180,9 +149,7 @@ export default function AdminMinutesPage() {
                   id="min-title"
                   type="text"
                   value={form.title}
-                  onChange={(e) =>
-                    setForm({ ...form, title: e.target.value })
-                  }
+                  onChange={(e) => setForm({ ...form, title: e.target.value })}
                   className="w-full px-3 py-2 border border-gray-300 rounded-md"
                   placeholder="e.g., March 2026 General Meeting"
                   required
@@ -201,26 +168,6 @@ export default function AdminMinutesPage() {
                   required
                 />
               </div>
-              <div className="col-span-1 md:col-span-2">
-                <label htmlFor="min-file" className="block text-sm font-medium text-gray-700 mb-1">
-                  Upload Minutes (PDF, DOC, DOCX, TXT)
-                </label>
-                <input
-                  id="min-file"
-                  type="file"
-                  accept=".pdf,.doc,.docx,.txt"
-                  onChange={handleFileChange}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-md"
-                />
-                {form.fileUrl && (
-                  <p className="mt-1 text-sm text-green-600">
-                    File uploaded: {form.fileUrl.split("/").pop()}
-                  </p>
-                )}
-                {uploadError && (
-                  <p className="mt-1 text-sm text-red-600">{uploadError}</p>
-                )}
-              </div>
             </div>
             <div>
               <label htmlFor="min-content" className="block text-sm font-medium text-gray-700 mb-1">
@@ -229,9 +176,7 @@ export default function AdminMinutesPage() {
               <textarea
                 id="min-content"
                 value={form.content}
-                onChange={(e) =>
-                  setForm({ ...form, content: e.target.value })
-                }
+                onChange={(e) => setForm({ ...form, content: e.target.value })}
                 rows={12}
                 className="w-full px-3 py-2 border border-gray-300 rounded-md font-mono text-sm"
                 placeholder="## Attendance&#10;&#10;Present: ...&#10;&#10;## Agenda Items&#10;&#10;### 1. Treasurer's Report&#10;- ..."
@@ -254,7 +199,6 @@ export default function AdminMinutesPage() {
                 onClick={() => {
                   setShowForm(false);
                   setEditing(null);
-                  setUploadError("");
                 }}
                 className="text-gray-600 px-4 py-2 rounded-md hover:bg-gray-100"
               >

--- a/src/app/api/minutes/route.ts
+++ b/src/app/api/minutes/route.ts
@@ -19,7 +19,6 @@ export async function POST(request: NextRequest) {
     title: body.title,
     date: body.date,
     content: body.content,
-    fileUrl: body.fileUrl,
     createdAt: body.createdAt || new Date().toISOString(),
   };
 

--- a/src/components/MinutesCard.tsx
+++ b/src/components/MinutesCard.tsx
@@ -18,33 +18,11 @@ export default function MinutesCard({ minutes }: { minutes: Minutes }) {
         </div>
       </div>
 
-      {minutes.fileUrl ? (
-        <div className="flex gap-4">
-          <Link
-            href={`/minutes/${minutes.id}`}
-            className="inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500"
-          >
-            Read Online
-          </Link>
-          <a
-            href={minutes.fileUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-primary-600 hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500"
-          >
-            <svg className="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
-            </svg>
-            Download Minutes
-          </a>
-        </div>
-      ) : (
-        <Link href={`/minutes/${minutes.id}`}>
-          <p className="text-sm text-gray-600 line-clamp-2 hover:text-primary-600">
-            {minutes.content?.replace(/[#*\n]/g, " ").substring(0, 150)}...
-          </p>
-        </Link>
-      )}
+      <Link href={`/minutes/${minutes.id}`}>
+        <p className="text-sm text-gray-600 line-clamp-2 hover:text-primary-600">
+          {minutes.content?.replace(/[#*\n]/g, " ").substring(0, 150)}...
+        </p>
+      </Link>
     </div>
   );
 }

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -157,7 +157,6 @@ export async function getMinutes(): Promise<Minutes[]> {
     title: item.title,
     date: item.date,
     content: item.content,
-    fileUrl: item.file_url,
     createdAt: item.created_at
   }));
 }
@@ -179,7 +178,6 @@ export async function getMinutesById(id: string): Promise<Minutes | undefined> {
     title: data.title,
     date: data.date,
     content: data.content,
-    fileUrl: data.file_url,
     createdAt: data.created_at
   } : undefined;
 }
@@ -189,7 +187,6 @@ export async function saveMinutes(minutes: Minutes): Promise<void> {
     title: minutes.title,
     date: minutes.date,
     content: minutes.content,
-    file_url: minutes.fileUrl,
     created_at: minutes.createdAt || new Date().toISOString()
   };
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -13,7 +13,6 @@ export interface Minutes {
     title: string;
     date: string;
     content?: string;
-    fileUrl?: string;
     createdAt: string;
 }
 


### PR DESCRIPTION
- Removed fileUrl from Minutes type, admin form, API route, and MinutesCard
- MinutesCard now always shows content preview instead of conditional download button
- Removed file upload tests (invalid file type, re-upload) from admin minutes spec
- Removed download button test from public minutes spec
- Removed fileInput locator from AdminMinutesPage page object
- Removed getDownloadButtons() from MinutesPage page object