### PR TITLE
Add E2E tests job to staging workflow against Vercel preview URL

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -32,6 +32,8 @@ jobs:
     name: Deploy to Vercel Staging
     runs-on: ubuntu-latest
     needs: migrate-staging-db
+    outputs:
+      url: ${{ steps.deploy.outputs.url }}
     environment:
       name: staging
       url: ${{ steps.deploy.outputs.url }}
@@ -70,3 +72,39 @@ jobs:
               repo: context.repo.repo,
               body: `✅ Staging deploy ready: ${{ steps.deploy.outputs.url }}`
             })
+
+  e2e-tests:
+    name: E2E Tests (Playwright)
+    runs-on: ubuntu-latest
+    needs: deploy-staging
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: e2etest/package-lock.json
+
+      - name: Install Playwright dependencies
+        working-directory: e2etest
+        run: npm ci
+
+      - name: Install Playwright browsers
+        working-directory: e2etest
+        run: npx playwright install --with-deps chromium
+
+      - name: Run E2E tests
+        working-directory: e2etest
+        env:
+          PLAYWRIGHT_BASE_URL: ${{ needs.deploy-staging.outputs.url }}
+          ADMIN_PASSWORD: ${{ secrets.ADMIN_PASSWORD }}
+        run: npm test
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: e2etest/playwright-report/
+          retention-days: 7


### PR DESCRIPTION
After deploy-staging succeeds, run the full Playwright suite pointed at the live preview URL. Upload HTML report as artifact on every run. Requires ADMIN_PASSWORD secret in GitHub for auth setup.

https://claude.ai/code/session_01HSM7v5c8vK7oReEcdisP3K