### PR TITLE
fix: prevent Invalid URL crash when Supabase env vars are missing at …

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,10 +1,13 @@
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || '';
-const supabaseServiceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY || '';
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseServiceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 
 if (!supabaseUrl || !supabaseServiceRoleKey) {
     console.warn('Supabase URL or Service Role Key is missing. Check your environment variables.');
 }
 
-export const supabase = createClient(supabaseUrl, supabaseServiceRoleKey);
+export const supabase = createClient(
+    supabaseUrl ?? 'http://localhost',
+    supabaseServiceRoleKey ?? 'placeholder'
+);


### PR DESCRIPTION
…build time

createClient with an empty string calls new URL('') internally, crashing static page generation. Fall back to a valid placeholder URL/key so the build completes; runtime calls still fail fast via the existing console.warn.

https://claude.ai/code/session_01HSM7v5c8vK7oReEcdisP3K