### PR TITLE
fix: set NEXTAUTH_URL from VERCEL_URL on Vercel preview builds

### DIFF
--- a/src/lib/auth-options.ts
+++ b/src/lib/auth-options.ts
@@ -1,6 +1,12 @@
 import { NextAuthOptions } from "next-auth";
 import CredentialsProvider from "next-auth/providers/credentials";
 
+// Vercel generates the preview URL dynamically; NextAuth requires NEXTAUTH_URL to be a valid URL.
+// Fall back to VERCEL_URL (injected automatically by Vercel) so builds don't crash.
+if (!process.env.NEXTAUTH_URL && process.env.VERCEL_URL) {
+  process.env.NEXTAUTH_URL = `https://${process.env.VERCEL_URL}`;
+}
+
 export const authOptions: NextAuthOptions = {
   providers: [
     CredentialsProvider({


### PR DESCRIPTION
NEXTAUTH_URL is not statically set on Vercel — it is generated dynamically per deployment. Without it, NextAuth calls new URL('') during static page generation and crashes the build. Fall back to VERCEL_URL which Vercel injects automatically at build time.

https://claude.ai/code/session_01HSM7v5c8vK7oReEcdisP3K