### PR TITLE
fix: guarantee NEXTAUTH_URL is always set during CI builds

### DIFF
--- a/src/lib/auth-options.ts
+++ b/src/lib/auth-options.ts
@@ -1,10 +1,13 @@
 import { NextAuthOptions } from "next-auth";
 import CredentialsProvider from "next-auth/providers/credentials";
 
-// Vercel generates the preview URL dynamically; NextAuth requires NEXTAUTH_URL to be a valid URL.
-// Fall back to VERCEL_URL (injected automatically by Vercel) so builds don't crash.
-if (!process.env.NEXTAUTH_URL && process.env.VERCEL_URL) {
-  process.env.NEXTAUTH_URL = `https://${process.env.VERCEL_URL}`;
+// Ensure NEXTAUTH_URL is always a valid URL at build time.
+// VERCEL_URL is injected by Vercel at runtime; during CI builds it may be absent,
+// so fall back to localhost to prevent new URL('') from crashing static generation.
+if (!process.env.NEXTAUTH_URL) {
+  process.env.NEXTAUTH_URL = process.env.VERCEL_URL
+    ? `https://${process.env.VERCEL_URL}`
+    : 'http://localhost:3000';
 }
 
 export const authOptions: NextAuthOptions = {


### PR DESCRIPTION
VERCEL_URL is only injected inside Vercel's runtime, not during `vercel build` in GitHub Actions runners. Without a fallback, NEXTAUTH_URL stays undefined and next-auth crashes static page generation with TypeError: Invalid URL.

Fall back to http://localhost:3000 when neither NEXTAUTH_URL nor VERCEL_URL is available — this value is never used at runtime, it only prevents new URL('') from throwing during the build.

Fixes #21

https://claude.ai/code/session_01U3zaiJB3MB6J4n27DdwHgy